### PR TITLE
Fix Duplex printing on OKI B401dn

### DIFF
--- a/SFP/monochrome/desktop/MB400PCL/OK400PCL.ppd
+++ b/SFP/monochrome/desktop/MB400PCL/OK400PCL.ppd
@@ -238,17 +238,17 @@
 *DefaultDuplex: None
 *Duplex None/None: "
  <<
- /Duplex false /Tumble false /Policies << /Duplex 2 >>
+ /Duplex false /Tumble false
  >> setpagedevice"
 *End
 *Duplex DuplexNoTumble/Long-Edge Binding: "
  <<
- /Duplex true /Tumble false /Policies << /Duplex 2 >>
+ /Duplex true /Tumble false
  >> setpagedevice"
 *End
 *Duplex DuplexTumble/Short-Edge Binding: "
  <<
- /Duplex true /Tumble true /Policies << /Duplex 2 >>
+ /Duplex true /Tumble true
  >> setpagedevice"
 *End
 *CloseUI: *Duplex


### PR DESCRIPTION
Note: duplex printing works, but /only/ with long-edge binding

Bug-Debian: https://bugs.debian.org/938989